### PR TITLE
Fix typos in CV

### DIFF
--- a/index.html
+++ b/index.html
@@ -468,7 +468,7 @@
                  </ul>
                  <h4>Cle Elum Sockeye Smolt Trap and Haul</h4>
                  <ul>
-                    <li>Set and fished <a href="https://drive.google.com/file/d/11QwCCFrVx7v4lpyj4huroJaQpg3TzSxF/view?usp=drive_link" target="_blank" rel="noopener noreferrer">Onedia nets</a></li>
+                    <li>Set and fished <a href="https://drive.google.com/file/d/11QwCCFrVx7v4lpyj4huroJaQpg3TzSxF/view?usp=drive_link" target="_blank" rel="noopener noreferrer">Oneida nets</a></li>
                     <li>Coordinated USFWS, WDFW, Yakama Nation, and Bureau of Reclamation</li>
                     <li>Trained staff and volunteers on how to operate and collect <a href="https://drive.google.com/file/d/1XiPV-WQK_qjtJjSFaLjbdS_iGQHaQcGm/view?usp=drive_link" target="_blank" rel="noopener noreferrer">smolts</a> from nets</li>
                  </ul>
@@ -476,8 +476,8 @@
                  <ul>
                     <li>Perform Bull Trout dewatering rescues and <a href="https://drive.google.com/file/d/1EKnD7y6SV4223BW7X0drgJtqMgSfpKfh/view?usp=drive_link" target="_blank" rel="noopener noreferrer">redd surveys</a>.</li>
                     <li>Assist with <a href="https://drive.google.com/file/d/1XQkExoBZEyYr8Bk6HK4FCk_jHrMUpmqJ/view?usp=drive_link" target="_blank" rel="noopener noreferrer">flume construction</a> for fish passage.</li>
-                    <li>Assit BOR staff with fish recovery in <a href="https://drive.google.com/file/d/1J8EZpAhZtA-2rQiExsyB-pfdlhjqINxg/view?usp=drive_link" target="_blank" rel="noopener noreferrer">irrigation infrastructure</a></li>
-                    <li>Assist Hatchery staff with <a href="https://drive.google.com/file/d/1csIgQqvCQM3IPl7DTh2lV-3QHKTTeNT3/view?usp=drive_link" target="_blank" rel="noopener noreferrer">various task</a></li>
+                    <li>Assist BOR staff with fish recovery in <a href="https://drive.google.com/file/d/1J8EZpAhZtA-2rQiExsyB-pfdlhjqINxg/view?usp=drive_link" target="_blank" rel="noopener noreferrer">irrigation infrastructure</a></li>
+                    <li>Assist Hatchery staff with <a href="https://drive.google.com/file/d/1csIgQqvCQM3IPl7DTh2lV-3QHKTTeNT3/view?usp=drive_link" target="_blank" rel="noopener noreferrer">various tasks</a></li>
                  </ul>
 
                  <h4>Administrative & Logistics</h4>
@@ -619,7 +619,7 @@
                 <h4>Teaching Assistant Roles</h4>
                  <ul>
                     <li>Ichthyology</li>
-                    <li>Principals of Wildlife Management</li>
+                    <li>Principles of Wildlife Management</li>
                     <li>Fisheries Management</li>
                     <li>Intro to Biology</li>
                  </ul>
@@ -681,7 +681,7 @@
                  <h3>Field & Survey Techniques</h3>
                 <ul class="skills-list">
                     <li>Electrofishing (Boat, Backpack, Parallel wire)</li>
-                    <li>Netting (Hoop, Gill, Trammel, Onedia, Seining)</li>
+                    <li>Netting (Hoop, Gill, Trammel, Oneida, Seining)</li>
                     <li>eDNA Collection & Sampling</li>
                     <li>External Fish Tagging (e.g., Floy)</li>
                     <li>Internal Fish Tagging (PIT, Acoustic - Vemco/JSATS)</li>
@@ -709,7 +709,7 @@
                     <li>Microsoft Office Suite (Excel, Word, PowerPoint, Access)</li>
                     <li>Github (Version Control)</li>
                     <li>Biomark Device Manager</li>
-                    <li>Leveraging Artifical Intellegance</li>
+                    <li>Leveraging Artificial Intelligence</li>
                 </ul>
             </div>
 
@@ -812,7 +812,7 @@
              <div class="references-list">
                 <div class="ref-entry">
                     <p><strong>Jason Romine, Ph.D.</strong></p>
-                    <p>Senior Scientist, Klienschmidt Group</p>
+                    <p>Senior Scientist, Kleinschmidt Group</p>
                     <p><a href="mailto:Jason.Romine@kleinschmidtgroup.com">Jason.Romine@kleinschmidtgroup.com</a> | <a href="tel:971-266-5395">(971)-266-5395</a></p>
                 </div>
                  <div class="ref-entry">


### PR DESCRIPTION
## Summary
- fix typos in skills and experience sections
- clean up professional reference text

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_6842f8e2eb6c8320995f6b4dc3e8343a